### PR TITLE
Allow Client-Specified Secret Overlap Duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 2.1.0 (Released 2023-06-29)
+
+- Allow Client-Specified Secret Overlap Duration
+
 ## Version 2.0.2 (Released 2023-06-21)
 
 - Correct Serialization of DateTime Values

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:820870426321:applications/platform-client-secret-rotator
-        SemanticVersion: 2.0.2
+        SemanticVersion: 2.1.0
       Parameters:
         Endpoint: !Sub https://secretsmanager.${AWS::Region}.${AWS::URLSuffix}
         FunctionName: !Sub ${AWS::StackName}-client-credentials-secret-rotator

--- a/rotator/requirements.txt
+++ b/rotator/requirements.txt
@@ -1,3 +1,4 @@
 boto3~=1.26.145
+isoduration~=20.11.0
 requests~=2.31.0
 uritemplate~=4.1.1

--- a/rotator/rotator.py
+++ b/rotator/rotator.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import boto3
+import isoduration
 import json
 import logging
 import os
@@ -235,9 +236,11 @@ def _set_client_secret(secret_dict, access_token):
 
     This helper function sets the client secret
     """
+    overlap_period = isoduration.parse_duration(os.environ['OVERLAP_PERIOD'])
+    expire_previous_secrets_at = datetime.now(timezone.utc) + overlap_period
     payload = {
         'client_secret': secret_dict['secret'],
-        'expire_previous_secrets_at': datetime.now(timezone.utc).isoformat(),
+        'expire_previous_secrets_at': expire_previous_secrets_at.isoformat(),
     }
     headers = {
         'Accept': 'application/json',

--- a/template.yml
+++ b/template.yml
@@ -26,7 +26,7 @@ Metadata:
     - rotator
     - client-secret
     HomePageUrl: https://github.com/Cimpress-MCP/Platform-Client-Secret-Rotator
-    SemanticVersion: 2.0.2
+    SemanticVersion: 2.1.0
     SourceCodeUrl: https://github.com/Cimpress-MCP/Platform-Client-Secret-Rotator
 
 Parameters:
@@ -54,6 +54,15 @@ Parameters:
     Type: String
     Description: The KMS key used to encrypt the secret being rotated.
     Default: ''
+  OverlapDuration:
+    Type: String
+    Description: >-
+      The amount of time after rotation for which a previous client secret will be active.
+      This value should be taken into account when determining rotation cadence, as it
+      could keep a client secret active longer than is compliant.
+    Default: P1D
+    AllowedPattern: ^\+?P
+    ConstraintDescription: Must be a valid positive ISO duration. (P1D, PT8H, PT1H30M, &c.)
 
 Conditions:
   KmsKeyArnExists: !Not [ !Equals [ '', !Ref KmsKeyArn ] ]
@@ -86,6 +95,7 @@ Resources:
         Variables:
           AUDIENCE: !Ref Audience
           ISSUER: !Ref Issuer
+          OVERLAP_DURATION: !Ref OverlapDuration
           SECRETS_MANAGER_ENDPOINT: !Ref Endpoint
       Tags:
         SecretsManagerLambda: Rotation


### PR DESCRIPTION
I'm _very tempted_ to try to limit this to a day or less, but I don't think I can do that in a regex without tying myself in knots. I'll at least make sure it starts with (an optional plus sign followed by) a P so that there's a hope of validity. I don't expect anyone will adjust this value, frankly, but there's little harm in the possibility.